### PR TITLE
Added grep in revision history

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ takes one of the following arguments or flags
 |:------------ |:----------------------------------------- |:------
 | -a,adds      | add files to staging area                 | enter: add files to staging area<br>ctrl-d: diff selected file
 | -r,runs      | show github workflow runs and filter logs | enter: search run logs
+| -g,greps     | grep in files in revision history         | interactive prompt: insert regex, select files, show pattern in revision history
 | -p,prs       | view, diff and checkout PR                | enter: checkout selected PR<br>ctrl-d: diff selected PR<br>ctrl-v: view selected PR
 | -b,branches  | checkout and diff branches                | enter: checkout selected branch<br>ctrl-d: diff selected branch<br>ctrl-x: delete selected branch
 | -l,logs      | select commits and show diff              | enter: show selected commit diff

--- a/gh-f
+++ b/gh-f
@@ -17,6 +17,7 @@ gh f [cmd]
 COMMANDS
   -a|adds: add to staging area
   -r|runs: show github workflow runs and filter logs
+  -g|greps: grep in files in revision history
   -p|prs: view, diff and checkout PR
   -b|branches: checkout and diff branches
   -l|logs: select commits and show diff
@@ -38,6 +39,13 @@ USAGE
 
 	enter: search the selected run logs
 	exits if no runs exist
+
+  gh f -g | gh f greps
+
+    prompt for regex pattern to grep
+    select files whose revisions contain pattern
+    show pattern in revision history
+	enter: show file at point in time of revision
 
   gh f -p | gh f prs
 

--- a/gh-f
+++ b/gh-f
@@ -155,7 +155,7 @@ greps() {
 				--exit-0 \
 				--ansi \
 				--prompt="commits containing $regex in $revision_files:" \
-				--preview="git show {}:$revision_files | grep $regex --colour"
+				--preview="git show {}:$revision_files | grep \"$regex\""
 	)"
 	[[ -n "$revision" ]] && git show "$revision":$revision_files
 }

--- a/gh-f
+++ b/gh-f
@@ -132,6 +132,25 @@ adds() {
 	fi
 }
 
+greps() {
+	if ! is_git_repo; then {
+		echo "not a git repo"
+		exit
+	}; fi
+	read -rp "search regex: " regex
+	[[ -z $regex ]] && exit
+
+	git_files="$(
+		git ls-files . --exclude-standard |
+			fzf \
+				--ansi \
+				--prompt="revision files:" \
+				--multi \
+				--preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS git log --oneline --color=always {1}'
+	)"
+
+}
+
 runs() {
 	if ! is_remote; then {
 		echo "no gh remote found"
@@ -301,6 +320,10 @@ while [[ "$#" -gt 0 ]]; do
 		;;
 	-a | adds)
 		adds
+		shift
+		;;
+	-g | greps)
+		greps
 		shift
 		;;
 	-r | runs)

--- a/gh-f
+++ b/gh-f
@@ -140,15 +140,24 @@ greps() {
 	read -rp "search regex: " regex
 	[[ -z $regex ]] && exit
 
-	git_files="$(
-		git ls-files . --exclude-standard |
+	revision_files="$(
+		git rev-list --all | xargs git grep $regex | awk -F':' '{print $2}' | sort -u |
 			fzf \
+				--exit-0 \
 				--ansi \
-				--prompt="revision files:" \
-				--multi \
-				--preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS git log --oneline --color=always {1}'
+				--prompt="files containing '$regex' in revisions:" \
+				--preview="git log --oneline --format='%C(bold blue)%h%C(reset) - %C(green)%ar%C(reset) - %C(cyan)%an%C(reset)%C(bold yellow)%d%C(reset): %s' --color=always {}"
 	)"
-
+	[[ -n "$revision_files" ]] && revision="$(
+		git rev-list --all -- $revision_files | xargs -I {} git grep "$regex" {} -- $revision_files |
+			awk -F':' -v ID_COLOUR="$ID_COLOUR" -v TEXT_COLOUR="$TEXT_COLOUR" -v SHELL_COLOUR="$SHELL_COLOUR" '{print ID_COLOUR $1}' | sort -u |
+			fzf \
+				--exit-0 \
+				--ansi \
+				--prompt="commits containing $regex in $revision_files:" \
+				--preview="git show {}:$revision_files | grep $regex --colour"
+	)"
+	[[ -n "$revision" ]] && git show "$revision":$revision_files
 }
 
 runs() {

--- a/gh-f
+++ b/gh-f
@@ -140,6 +140,21 @@ adds() {
 	fi
 }
 
+runs() {
+	if ! is_remote; then {
+		echo "no gh remote found"
+		exit
+	}; fi
+	gh run list -L100 | awk -F'\t' -v ID_COLOUR="$ID_COLOUR" -v TEXT_COLOUR="$TEXT_COLOUR" -v STATUS_COLOUR="$STATUS_COLOUR" -v SHELL_COLOUR="$SHELL_COLOUR" \
+		'{print ID_COLOUR $7 SHELL_COLOUR": " TEXT_COLOUR $4 SHELL_COLOUR" - " STATUS_COLOUR $2 SHELL_COLOUR" - "$9}' |
+		fzf \
+			--exit-0 \
+			--ansi --delimiter=: \
+			--prompt="runs logs:" \
+			--preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS gh run view {1}' \
+			--bind "enter:execute:(gh run view --log {1} | $LOG_PAGER)"
+}
+
 greps() {
 	if ! is_git_repo; then {
 		echo "not a git repo"
@@ -169,21 +184,6 @@ greps() {
 		printf 'commit: %s\nfile: %s\n' "$revision" "$revision_files"
 		git show "$revision":$revision_files
 	fi
-}
-
-runs() {
-	if ! is_remote; then {
-		echo "no gh remote found"
-		exit
-	}; fi
-	gh run list -L100 | awk -F'\t' -v ID_COLOUR="$ID_COLOUR" -v TEXT_COLOUR="$TEXT_COLOUR" -v STATUS_COLOUR="$STATUS_COLOUR" -v SHELL_COLOUR="$SHELL_COLOUR" \
-		'{print ID_COLOUR $7 SHELL_COLOUR": " TEXT_COLOUR $4 SHELL_COLOUR" - " STATUS_COLOUR $2 SHELL_COLOUR" - "$9}' |
-		fzf \
-			--exit-0 \
-			--ansi --delimiter=: \
-			--prompt="runs logs:" \
-			--preview='GH_FORCE_TTY=$FZF_PREVIEW_COLUMNS gh run view {1}' \
-			--bind "enter:execute:(gh run view --log {1} | $LOG_PAGER)"
 }
 
 prs() {
@@ -342,12 +342,12 @@ while [[ "$#" -gt 0 ]]; do
 		adds
 		shift
 		;;
-	-g | greps)
-		greps
-		shift
-		;;
 	-r | runs)
 		runs
+		shift
+		;;
+	-g | greps)
+		greps
 		shift
 		;;
 	-p | prs)

--- a/gh-f
+++ b/gh-f
@@ -155,7 +155,7 @@ greps() {
 				--exit-0 \
 				--ansi \
 				--prompt="commits containing $regex in $revision_files:" \
-				--preview="git show {}:$revision_files | grep \"$regex\""
+				--preview="git show {}:$revision_files | grep -n  --color=always \"$regex\""
 	)"
 	[[ -n "$revision" ]] && git show "$revision":$revision_files
 }

--- a/gh-f
+++ b/gh-f
@@ -157,7 +157,10 @@ greps() {
 				--prompt="commits containing $regex in $revision_files:" \
 				--preview="git show {}:$revision_files | grep -n  --color=always \"$regex\""
 	)"
-	[[ -n "$revision" ]] && git show "$revision":$revision_files
+	if [[ -n "$revision" ]]; then
+		printf 'commit: %s\nfile: %s\n' "$revision" "$revision_files"
+		git show "$revision":$revision_files
+	fi
 }
 
 runs() {


### PR DESCRIPTION
- initialised skeleton for greps() function
- sort unique the revisions after listing the revision files
- escaped regex in fzf preview
- added line number and colour in grep preview
- added printf option to print revision commit and filename before git show
- added greps() to help and README
