### PR TITLE
Fix the gh alias command examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Most commands follow the semantics of `git` standard instructions (so that you c
 ## Customisation
 If you want to skip typing `gh f` before each command you may alias it directly, for instance
 ```
-gh set alias prs `f -p` # show PRs
-gh set alias l `f -l` # show git logs
+gh alias set prs 'f -p' # show PRs
+gh alias set l 'f -l' # show git logs
 ```
 and likewise for the rest.
 


### PR DESCRIPTION
Fix the call to set the aliases for the `gh` command using `gh alias set` rather than `gh set alias`. Found when trying to run the examples myself. Also set back-ticks to single-quotes to avoid potentially running them as sub-shells for Bash users.