### PR TITLE
Use less -R for log pager

### DIFF
--- a/gh-f
+++ b/gh-f
@@ -7,7 +7,7 @@ ID_COLOUR="\033[36m"
 TEXT_COLOUR="\033[34m"
 STATUS_COLOUR="\033[33m"
 SHELL_COLOUR="\033[0m"
-[[ -z $(command -v bat) ]] && HELP_PAGER="less" || HELP_PAGER="bat -l man -p"
+[[ -z $(command -v bat) ]] && HELP_PAGER="less -R" || HELP_PAGER="bat -l man -p"
 [[ -z $(command -v bat) ]] && LOG_PAGER="less -R" || LOG_PAGER="bat -l log -p"
 
 help() {

--- a/gh-f
+++ b/gh-f
@@ -8,7 +8,7 @@ TEXT_COLOUR="\033[34m"
 STATUS_COLOUR="\033[33m"
 SHELL_COLOUR="\033[0m"
 [[ -z $(command -v bat) ]] && HELP_PAGER="less" || HELP_PAGER="bat -l man -p"
-[[ -z $(command -v bat) ]] && LOG_PAGER="less" || LOG_PAGER="bat -l log -p"
+[[ -z $(command -v bat) ]] && LOG_PAGER="less -R" || LOG_PAGER="bat -l log -p"
 
 help() {
 	help_message="


### PR DESCRIPTION
According to help message, gh-f should use "less -R" for log pager if bat is missing on the running system. https://github.com/gennaro-tedesco/gh-f/blob/54befb3f4c929d06ca65ce67f71d776b1b87585e/gh-f#L113